### PR TITLE
PE-8938 Updated version for eks-token to 0.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ importlib-metadata==2.0.0
 isort==5.5.4
 jmespath==0.10.0
 keyring==21.4.0
-lazy-object-proxy==0.0.0
+lazy-object-proxy==1.4.0
 mccabe==0.6.1
 packaging==20.4
 pkginfo==1.5.0.1

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as readme:
 
 setup(
     name='eks_token',
-    version='0.1.0',
+    version='0.1.1',
     author='Peak AI',
     author_email='support@peak.ai',
     description='EKS Token package, an alternate to "aws eks get-token ..." CLI',


### PR DESCRIPTION
# Description

*Depends on:*
None

_Description of what this PR does. What have you added or changed, and why?_
Updates the eks-token version to 0.1.1. Updated to 0.1.1 in order to bumb up bleach from 3.2.1 to 3.3.0 by dependabot

# Steps to test
1. Try to clone and test if everything is working as expected