### PR TITLE
chore: Update hardcoded version of AWS CLI and botocore

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-awscli==1.27.8
-botocore==1.29.8
+awscli>=1.27.8
+botocore>=1.29.8
 colorama==0.4.4
 docutils==0.16
 jmespath==1.0.1


### PR DESCRIPTION
# Description
The current requirements file prevents the installation of this module unless your aws cli and botocore modules match exactly the versions specified.  As those versions are outdated, the requirements changed to a minimum version instead of an absolute one.


*Depends on:*
- Links to any pull requests linked to this

_Description of what this PR does. What have you added or changed, and why?_

# Steps to test
1. Follow the readme to setup the package locally
2. Install and test the functionality