### PR TITLE
fix: Require a minimum awscli instead of exact version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     ],
     python_requires='>=3.6',
     keywords='eks k8s boto3 awscli python aws',
-    install_requires=["awscli==1.27.8"],
+    install_requires=["awscli>=1.27.8"],
 )


### PR DESCRIPTION
The problem reported in #14 and fixed in PR #15 is still an issue--the PR missed one place this is specified in setup.py