### PR TITLE
Updated apiVersion to client.authentication.k8s.io/v1beta1

### DIFF
--- a/eks_token/logics.py
+++ b/eks_token/logics.py
@@ -14,7 +14,7 @@ def get_token(cluster_name: str, role_arn: str = None) -> dict:
     token = TokenGenerator(sts_client).get_token(cluster_name)
     return {
             "kind": "ExecCredential",
-            "apiVersion": "client.authentication.k8s.io/v1alpha1",
+            "apiVersion": "client.authentication.k8s.io/v1beta1",
             "spec": {},
             "status": {
                 "expirationTimestamp": get_expiration_time(),


### PR DESCRIPTION
# Description

*Depends on:*
- Links to any pull requests linked to this

_Description of what this PR does. What have you added or changed, and why?_
PR for updating the client apiVersion. client.authentication.k8s.io/v1alpha1 is no longer supported. PR to return client.authentication.k8s.io/v1beta1  as the apiVersion which is what aws currently uses when using 'aws eks token'.
# Steps to test
1.
2.
3.